### PR TITLE
Collect client errors and send to api

### DIFF
--- a/client/src/actions/users.ts
+++ b/client/src/actions/users.ts
@@ -5,6 +5,7 @@ import axios from 'axios'
 import { actionTypes, ROOT_URL } from '../constants'
 import { BaseAction } from './static-types'
 import { User } from '../constants/static-types'
+import { ReduxAPIError } from '../reducers/static-types'
 import { CreateUserValues, CreateSessionValues } from '../components/organisms/Form/types'
 import { toHash } from '../constants/functions'
 
@@ -16,7 +17,7 @@ interface UserAPIRequest extends BaseAction {
 
 interface UserAPIFailure extends BaseAction {
   type: string
-  payload: { error: any } // TODO: 厳格に
+  payload: { error: ReduxAPIError }
 }
 
 interface CreateUserAction extends BaseAction {
@@ -63,7 +64,7 @@ export type CurrentUserAction =
   // | UpdateUserImgAction
   | UpdateProfileAction
 
-const userAPIFailure = (error: any) => ({
+const userAPIFailure = (error: ReduxAPIError) => ({
   type: actionTypes.USER_API_FAILURE,
   payload: { error },
 })
@@ -85,9 +86,12 @@ export const createUser = (values: CreateUserValues): CurrentUserThunkActionType
           payload: { currentUser: res.data },
         })
       })
-      .catch(err => {
-        // TODO: errの型が{status: string, message: string}でない場合(想定していないエラーの場合)、APIにエラーログを投げる
-        dispatch(userAPIFailure(err))
+      .catch((err: ReduxAPIError) => {
+        if ('status' in err && 'message' in err) {
+          dispatch(userAPIFailure(err))
+        } else {
+          dispatch(userAPIFailure({ statusCode: 500, message: 'Unexpected error' }))
+        }
       })
   }
 }
@@ -110,9 +114,12 @@ export const createSession = (values: CreateSessionValues): CurrentUserThunkActi
           payload: { currentUser: res.data },
         })
       })
-      .catch(err => {
-        // TODO: errの型が{status: string, message: string}でない場合(想定していないエラーの場合)、APIにエラーログを投げる
-        dispatch(userAPIFailure(err))
+      .catch((err: ReduxAPIError) => {
+        if ('status' in err && 'message' in err) {
+          dispatch(userAPIFailure(err))
+        } else {
+          dispatch(userAPIFailure({ statusCode: 500, message: 'Unexpected error' }))
+        }
       })
   }
 }
@@ -138,9 +145,12 @@ export const updateProfile = (
           payload: { updatedUser: res.data },
         })
       })
-      .catch(err => {
-        // TODO: errの型が{status: string, message: string}でない場合(想定していないエラーの場合)、APIにエラーログを投げる
-        dispatch(userAPIFailure(err))
+      .catch((err: ReduxAPIError) => {
+        if ('status' in err && 'message' in err) {
+          dispatch(userAPIFailure(err))
+        } else {
+          dispatch(userAPIFailure({ statusCode: 500, message: 'Unexpected error' }))
+        }
       })
   }
 }

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -5,9 +5,12 @@ import { createStore, applyMiddleware } from 'redux'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import reducers from './reducers'
 import thunk from 'redux-thunk'
+import axios from 'axios'
 
 import Hello from './components/Hello'
 import Auth from './components/utils/auth'
+
+import { ROOT_URL } from './constants'
 
 const store = createStore(reducers, applyMiddleware(thunk))
 
@@ -26,3 +29,12 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('app')
 )
+
+if (process.env.NODE_ENV === 'production') {
+  window.addEventListener('error', e => {
+    const { message, filename, lineno, colno } = e
+    // TODO: Backendでデータを整形しSlackへ投稿
+    // NOTE: 'Script error.'しか帰ってこない場合は以下参照 -> https://qiita.com/sue71/items/885caeedb02ae6dc48c4
+    axios.post(`${ROOT_URL}/errors`, { message, filename, lineno, colno })
+  })
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
Clientのエラーログ収集
## 関連Issue
resolve #68
## 詳細
- [x] フロントエンドの純粋なエラー(cannot find 'hoge' of undefined など)
-> `window.addEventlister`で回収しAPIへ詳細なデータを送る
- [x] action発火時のエラー(500系)
~-> actionの`.catch`内でAPIにエラーデータを送るactionを発火~
-> internal server error が起きた時はバックエンドで上手いことresqueしてほしい

それぞれBackendで受け取り整形後Slackへ投稿
## 対象ページ

## TodoList

## 特にレビューしてほしいところ

## その他
